### PR TITLE
use entry_points which is more cross-platform reliable

### DIFF
--- a/multical/app/multical.py
+++ b/multical/app/multical.py
@@ -1,5 +1,3 @@
-#!python3
-
 from dataclasses import dataclass
 from multical.config.arguments import run_with
 from multiprocessing import cpu_count
@@ -26,5 +24,8 @@ class Multical:
     return self.command.execute()
 
 
-if __name__ == '__main__':
+def cli():
   run_with(Multical)
+
+if __name__ == '__main__':
+  cli()

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     description="Flexible multi-camera multi-board camera calibration library and application.",
     url="https://github.com/saulzar/multical",
     packages=find_namespace_packages(),
-    scripts=['multical/app/multical'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
@@ -25,6 +24,11 @@ setup(
         "Topic :: Multimedia :: Graphics :: Capture :: Digital Camera"
     ],
 
+    entry_points={
+        'console_scripts': [
+            'multical = multical.app.multical:cli',
+        ],
+    },
 
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This ensures the entry point works on windows machines. I have not tested any of the other functionality (will do in due course).