### PR TITLE
Fix hard-coded maximum index of marker on the flipping function.

### DIFF
--- a/multical/board/aprilgrid.py
+++ b/multical/board/aprilgrid.py
@@ -127,7 +127,7 @@ class AprilGrid(Parameters, Board):
     def marker_x_index_flip(marker):
       for y_index in range(self.size[1]):
         for x_index in range(self.size[0] // 2):
-          x_index_to_change = 5 - x_index
+          x_index_to_change = self.size[0] - 1 - x_index
           x_coord, y_coord = index2coord(x_index, y_index)
           x_coord_to_change, _ = index2coord(x_index_to_change, y_index)
           marker1 = copy(markers[y_coord:y_coord + int(square_length), x_coord_to_change:x_coord_to_change + int(square_length)])


### PR DESCRIPTION
On the function flipping x-index of markers, I hard-coded the maximum index of marker as "5".
So this apriltag board creator will not work except for 6x6.
I fix it.
Sorry for my shitty mistake!