### PR TITLE
Fix marker font float error

### DIFF
--- a/multical/interface/viewer_image.py
+++ b/multical/interface/viewer_image.py
@@ -101,7 +101,7 @@ def add_point_markers(scene, points, board, color, options):
 
 def add_reprojections(scene, points, projected, inliers, boards, valid_boards, options):
   marker_font = QFont()
-  marker_font.setPixelSize(options.marker_size * 0.75)
+  marker_font.setPixelSize(int(options.marker_size * 0.75))
 
   frame_table = points._extend(proj=projected.points, inlier=inliers)
 


### PR DESCRIPTION
I get the following error message, so I'm just casting it to an int to fix the issue.

```
/opt/homebrew/lib/python3.10/site-packages/pyvista/utilities/helpers.py:507: UserWarning: Points is not a float type. This can cause issues when transforming or applying filters. Casting to ``np.float32``. Disable this by passing ``force_float=False``.
  warnings.warn(
/opt/homebrew/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1583: RuntimeWarning: All-NaN slice encountered
  result = np.apply_along_axis(_nanquantile_1d, axis, a, q,
Traceback (most recent call last):
  File "/opt/homebrew/bin/multical", line 8, in <module>
    sys.exit(cli())
  File "/opt/homebrew/lib/python3.10/site-packages/multical/app/multical.py", line 28, in cli
    run_with(Multical)
  File "/opt/homebrew/lib/python3.10/site-packages/multical/config/arguments.py", line 73, in run_with
    return program.app.execute()
  File "/opt/homebrew/lib/python3.10/site-packages/multical/app/multical.py", line 24, in execute
    return self.command.execute()
  File "/opt/homebrew/lib/python3.10/site-packages/multical/app/vis.py", line 17, in execute
    visualize(self)
  File "/opt/homebrew/lib/python3.10/site-packages/multical/app/vis.py", line 50, in visualize
    visualize_ws(ws)
  File "/opt/homebrew/lib/python3.10/site-packages/multical/app/vis.py", line 32, in visualize_ws
    visualizer.visualize(ws)
  File "/opt/homebrew/lib/python3.10/site-packages/multical/interface/visualizer.py", line 29, in visualize
    vis.update_workspace(workspace)
  File "/opt/homebrew/lib/python3.10/site-packages/multical/interface/visualizer.py", line 206, in update_workspace
    self.update_frame()
  File "/opt/homebrew/lib/python3.10/site-packages/multical/interface/visualizer.py", line 49, in f
    return func(self, *args, **kwargs)
  File "/opt/homebrew/lib/python3.10/site-packages/multical/interface/visualizer.py", line 54, in f
    return func(self)
  File "/opt/homebrew/lib/python3.10/site-packages/multical/interface/visualizer.py", line 273, in update_frame
    self.update_image()
  File "/opt/homebrew/lib/python3.10/site-packages/multical/interface/visualizer.py", line 49, in f
    return func(self, *args, **kwargs)
  File "/opt/homebrew/lib/python3.10/site-packages/multical/interface/visualizer.py", line 54, in f
    return func(self)
  File "/opt/homebrew/lib/python3.10/site-packages/multical/interface/visualizer.py", line 300, in update_image
    annotated_image = annotate_image(self.workspace, self.calibration,
  File "/opt/homebrew/lib/python3.10/site-packages/multical/interface/viewer_image.py", line 150, in annotate_image
    add_reprojections(scene, detections, projected, inliers, workspace.boards, valid_boards, options)
  File "/opt/homebrew/lib/python3.10/site-packages/multical/interface/viewer_image.py", line 104, in add_reprojections
    marker_font.setPixelSize(options.marker_size * 0.75)
TypeError: setPixelSize(self, int): argument 1 has unexpected type 'float'
```