### PR TITLE
Fix py_structs import errors across codebase

### DIFF
--- a/multical/app/calibrate.py
+++ b/multical/app/calibrate.py
@@ -2,7 +2,7 @@
 from multical.io.logging import setup_logging
 from .vis import visualize_ws
 
-from structs.struct import struct, map_none, to_structs
+from py_structs import struct, map_none, to_structs
 import numpy as np
 
 from multical.config import *

--- a/multical/app/intrinsic.py
+++ b/multical/app/intrinsic.py
@@ -8,10 +8,10 @@ from multical.image.detect import common_image_size
 from multical.io.logging import setup_logging
 from multical.io.logging import info
 
-from structs.struct import  map_list, pformat_struct, split_dict
+from py_structs import struct, map_list, pformat_struct, split_dict
 from multical import image
 
-from structs.numpy import struct, shape
+from py_structs.numpy import shape
 
 from multical.config.arguments import *
 

--- a/multical/board/__init__.py
+++ b/multical/board/__init__.py
@@ -8,7 +8,7 @@ from .calico_config import load_calico
 from typing import Tuple
 
 from omegaconf.omegaconf import OmegaConf, MISSING
-from structs.struct import struct
+from py_structs import struct
 
 from multical.io.logging import debug, info, error
 

--- a/multical/board/aprilgrid.py
+++ b/multical/board/aprilgrid.py
@@ -2,14 +2,14 @@ from copy import copy
 
 from multical.io.logging import error
 from multical.board.board import Board
-from structs.numpy import Table
+from py_structs.numpy import Table
 from multical.board.common import *
 from pprint import pformat
 from cached_property import cached_property
 import cv2
 import numpy as np
 
-from structs.struct import struct, choose, subset
+from py_structs import struct, choose, subset
 from multical.optimization.parameters import Parameters
 
 

--- a/multical/board/board.py
+++ b/multical/board/board.py
@@ -1,6 +1,6 @@
 from cached_property import cached_property
 import numpy as np
-from structs.struct import struct
+from py_structs import struct
 
 class Board(object):
   

--- a/multical/board/charuco.py
+++ b/multical/board/charuco.py
@@ -5,7 +5,7 @@ import cv2
 import numpy as np
 from .common import *
 
-from structs.struct import struct, choose, subset
+from py_structs import struct, choose, subset
 from multical.optimization.parameters import Parameters
 
 class CharucoBoard(Parameters, Board):

--- a/multical/board/common.py
+++ b/multical/board/common.py
@@ -2,7 +2,7 @@ import cv2
 import numpy as np
 
 
-from structs.struct import struct
+from py_structs import struct
 from multical.transform import rtvec
 
 

--- a/multical/camera.py
+++ b/multical/camera.py
@@ -3,15 +3,15 @@ import operator
 from cached_property import cached_property
 import numpy as np
 import cv2
-from structs.numpy import shape
+from py_structs.numpy import shape
 
-from structs.struct import subset, transpose_structs, transpose_lists
+from py_structs import subset, transpose_structs, transpose_lists
 
 from pprint import pformat
 
 from .transform import rtvec, matrix
 
-from structs.struct import struct
+from py_structs import struct
 from .optimization.parameters import Parameters
 
 from multiprocessing.pool import ThreadPool
@@ -20,7 +20,7 @@ from multical.threading import cpu_count
 import cv2
 from tqdm import tqdm
 
-from structs.struct import split_list
+from py_structs import split_list
 
 
 

--- a/multical/camera_fisheye.py
+++ b/multical/camera_fisheye.py
@@ -2,9 +2,9 @@ from functools import partial, reduce
 import operator
 from cached_property import cached_property
 import numpy as np
-from structs.numpy import shape
+from py_structs.numpy import shape
 
-from structs.struct import subset, transpose_structs, transpose_lists
+from py_structs import subset, transpose_structs, transpose_lists
 
 from pprint import pformat
 
@@ -12,7 +12,7 @@ from pprint import pformat
 from . import camera
 from .transform import rtvec, matrix
 
-from structs.struct import struct
+from py_structs import struct
 from .optimization.parameters import Parameters
 
 from multiprocessing.pool import ThreadPool
@@ -21,7 +21,7 @@ from multical.threading import cpu_count
 import cv2
 from tqdm import tqdm
 
-from structs.struct import split_list
+from py_structs import split_list
 
 
 

--- a/multical/config/arguments.py
+++ b/multical/config/arguments.py
@@ -4,7 +4,7 @@ from multiprocessing import cpu_count
 import os
 from typing import List, Optional, Union
 
-from structs.struct import Struct
+from py_structs import Struct
 
 from simple_parsing import ArgumentParser, choice
 from simple_parsing.helpers import list_field

--- a/multical/config/runtime.py
+++ b/multical/config/runtime.py
@@ -3,7 +3,7 @@ import multical.image as image
 from multical.io.logging import info
 from os import path
 
-from structs.struct import struct
+from py_structs import struct
 from multical.board import load_config, load_calico
 
 

--- a/multical/config/workspace.py
+++ b/multical/config/workspace.py
@@ -1,4 +1,4 @@
-from structs.struct import map_none
+from py_structs import map_none
 from multical.io.import_calib import load_calibration
 from multical.motion.static_frames import StaticFrames
 from multical.motion.rolling_frames import RollingFrames

--- a/multical/display.py
+++ b/multical/display.py
@@ -4,7 +4,7 @@ import numpy as np
 from .transform import rtvec
 from . import tables
 
-from structs.struct import struct
+from py_structs import struct
 from .image.display import display_stacked
 import palettable.colorbrewer.qualitative as palettes
 

--- a/multical/image/detect.py
+++ b/multical/image/detect.py
@@ -8,7 +8,7 @@ import numpy as np
 from multical.camera import  stereo_calibrate
 from multical.threading import parmap_lists
 
-from structs.struct import transpose_structs, struct, filter_none
+from py_structs import transpose_structs, struct, filter_none
 
 def load_image(filename):
   assert path.isfile(filename), f"load_image: file {filename} does not exist"

--- a/multical/io/detections.py
+++ b/multical/io/detections.py
@@ -2,7 +2,7 @@
 import pickle
 from multical.io.logging import info
 
-from structs.struct import struct
+from py_structs import struct
 
 def try_load_detections(filename, cache_key={}):
   try:

--- a/multical/io/export_calib.py
+++ b/multical/io/export_calib.py
@@ -2,7 +2,7 @@ import json
 from os import path
 import numpy as np
 
-from structs.struct import struct, to_dicts, transpose_lists
+from py_structs import struct, to_dicts, transpose_lists
 from multical.transform import matrix
 
 

--- a/multical/io/import_calib.py
+++ b/multical/io/import_calib.py
@@ -1,7 +1,7 @@
 import json
 import numpy as np
 
-from structs.struct import struct, to_structs
+from py_structs import struct, to_structs
 from multical.transform import matrix
 
 from multical.camera import Camera

--- a/multical/io/logging.py
+++ b/multical/io/logging.py
@@ -6,7 +6,7 @@ from sys import stdout
 from copy import copy
 
 import numpy as np
-from structs.struct import struct
+from py_structs import struct
 
 logger = logging.getLogger("calibration")
 

--- a/multical/motion/hand_eye.py
+++ b/multical/motion/hand_eye.py
@@ -1,6 +1,6 @@
 from multical.motion.static_frames import project_points
 import numpy as np
-from structs.struct import struct, subset
+from py_structs import struct, subset
 from multical import tables
 from multical.io.export_calib import export_poses
 from multical.optimization.parameters import IndexMapper, Parameters

--- a/multical/motion/rolling_frames.py
+++ b/multical/motion/rolling_frames.py
@@ -1,12 +1,12 @@
 from multical.motion.static_frames import project_cameras
 from cached_property import cached_property
 import numpy as np
-from structs.struct import struct, subset
+from py_structs import struct, subset
 from .motion_model import MotionModel
 
 from multical.optimization.parameters import IndexMapper, Parameters
 from multical import tables
-from structs.numpy import Table, shape
+from py_structs.numpy import Table, shape
 
 from multical.transform import rtvec, matrix
 from multical.transform.interpolate import interpolate_poses, lerp

--- a/multical/motion/static_frames.py
+++ b/multical/motion/static_frames.py
@@ -2,8 +2,8 @@ from cached_property import cached_property
 from multical.motion.motion_model import MotionModel
 from multical.optimization.pose_set import PoseSet
 import numpy as np
-from structs.numpy import Table, shape
-from structs.struct import struct, subset
+from py_structs.numpy import Table, shape
+from py_structs import struct, subset
 from multical import tables
 
 

--- a/multical/optimization/calibration.py
+++ b/multical/optimization/calibration.py
@@ -18,8 +18,8 @@ from multical.io.logging import LogWriter, info
 from . import parameters
 from .parameters import ParamList
 
-from structs.numpy import Table, shape
-from structs.struct import concat_lists, apply_none, struct, choose, subset, when
+from py_structs.numpy import Table, shape
+from py_structs import concat_lists, apply_none, struct, choose, subset, when
 
 from scipy import optimize
 

--- a/multical/optimization/hand_eye.py
+++ b/multical/optimization/hand_eye.py
@@ -1,8 +1,8 @@
 from multical.io.report import report_pose_errors
 from cached_property import cached_property
 import numpy as np
-from structs.numpy import table
-from structs.struct import subset
+from py_structs.numpy import table
+from py_structs import subset
 from .calibration import Calibration
 from multical.transform.hand_eye import hand_eye_robot_world
 

--- a/multical/optimization/parameters.py
+++ b/multical/optimization/parameters.py
@@ -3,11 +3,11 @@ from operator import add
 from pprint import pformat
 from typing import Any, Dict, Generic, List, TypeVar
 import numpy as np
-from structs.numpy import map_arrays, reduce_arrays, shape
+from py_structs.numpy import map_arrays, reduce_arrays, shape
 
 from cached_property import cached_property
 from scipy.sparse import lil_matrix
-from structs.struct import subset
+from py_structs import subset
 from numbers import Number
 
 

--- a/multical/optimization/pose_set.py
+++ b/multical/optimization/pose_set.py
@@ -1,5 +1,5 @@
 from multical import tables
-from structs.struct import struct, subset
+from py_structs import struct, subset
 from multical.optimization.parameters import Parameters
 from cached_property import cached_property
 from multical.io.export_calib import export_poses

--- a/multical/tables.py
+++ b/multical/tables.py
@@ -3,8 +3,8 @@ from multical.io.report import report_pose_errors
 from .io.logging import debug, info
 import numpy as np
 
-from structs.struct import transpose_structs, invert_keys
-from structs.numpy import shape_info, struct, Table, shape
+from py_structs import struct, transpose_structs, invert_keys
+from py_structs.numpy import shape_info, Table, shape
 
 from .transform import rtvec, matrix
 from . import graph

--- a/multical/threading.py
+++ b/multical/threading.py
@@ -3,7 +3,7 @@ from functools import partial
 from multiprocessing import Pool, cpu_count, get_logger
 from multiprocessing.pool import ThreadPool
 
-from structs.struct import map_list, concat_lists, split_list
+from py_structs import map_list, concat_lists, split_list
 
 from tqdm import tqdm
 import traceback

--- a/multical/transform/matrix.py
+++ b/multical/transform/matrix.py
@@ -1,8 +1,8 @@
 import numpy as np
 import math
 
-from structs.numpy import shape
-from structs.struct import choose, struct
+from py_structs.numpy import shape
+from py_structs import choose, struct
 from . import common
 
 from scipy.spatial.transform import Rotation as R

--- a/multical/workspace.py
+++ b/multical/workspace.py
@@ -16,11 +16,11 @@ from multical.io import export_json, try_load_detections, write_detections
 from multical.image.detect import common_image_size
 
 from multical.optimization.calibration import Calibration, select_threshold
-from structs.struct import map_list, split_dict, struct, subset, to_dicts
+from py_structs import map_list, split_dict, struct, subset, to_dicts
 from . import tables, image
 from .camera import calibrate_cameras
 
-from structs.numpy import shape
+from py_structs.numpy import shape
 
 from .camera_fisheye import calibrate_cameras_fisheye
 from .io.logging import MemoryHandler, info


### PR DESCRIPTION
When installing from source using `python3 -m pip install ".[interactive]"` and trying to run `multical -h`, there are import errors across multiple files.
This is running on Python3.8 inside a virtual environment.

Upon investigation, it would appear to be originating from the `py_structs` package, which seems to be using a different directory structure than what `multical` is expecting. This might be due to a change upstream, maybe.
This PR fixes all import errors and allows `multical -h` to run without crashing/errors. Whether calibration actually works is a different issue, and is under testing.