### PR TITLE
Non-overlapping functionality with some other adjustments

### DIFF
--- a/multical/__init__.py
+++ b/multical/__init__.py
@@ -1,1 +1,1 @@
-from . import app, board, camera, config, display, graph, image, io, motion, optimization, tables, threading, transform, workspace
+from . import app, board, camera, config, display, graph, hand_eye, image, io, motion, optimization, tables, threading, transform, workspace

--- a/multical/board/common.py
+++ b/multical/board/common.py
@@ -35,16 +35,16 @@ def has_min_detections_grid(grid_size, ids, min_points, min_rows):
 
 def estimate_pose_points(board, camera, detections):
     if not board.has_min_detections(detections):
-        return None
+        return None, 0
 
-    undistorted = camera.undistort_points(detections.corners)      
-    valid, rvec, tvec = cv2.solvePnP(board.points[detections.ids], 
-      undistorted, camera.intrinsic, np.zeros(0))
+    undistorted = camera.undistort_points(detections.corners).astype('float32')
+    objPoints = board.points[detections.ids].astype('float32')
+    valid, rvec, tvec, error = cv2.solvePnPGeneric(objPoints, undistorted, camera.intrinsic, camera.dist)
 
     if not valid:
-      return None
+      return None, 0
 
-    return rtvec.join(rvec.flatten(), tvec.flatten())
+    return rtvec.join(rvec[0].flatten(), tvec[0].flatten()), error[0][0]
 
 
 def subpix_corners(image, detections, window):

--- a/multical/camera.py
+++ b/multical/camera.py
@@ -25,7 +25,7 @@ from structs.struct import split_list
 
 
 class Camera(Parameters):
-  def __init__(self, image_size, intrinsic, dist, model='standard', fix_aspect=False, has_skew=False):
+  def __init__(self, image_size, intrinsic, dist, model='standard', fix_aspect=False, has_skew=False, error_perview=None, intrinsic_dataset={}):
 
     assert model in Camera.model,\
         f"unknown camera model {model} options are {list(self.model.keys())}"
@@ -37,6 +37,8 @@ class Camera(Parameters):
     self.dist = np.zeros(5) if dist is None else dist
     self.fix_aspect = fix_aspect
     self.has_skew = has_skew
+    self.error_perview = error_perview #
+    self.intrinsic_dataset = intrinsic_dataset  # Collects views that are used for intrinsic calibration
 
   model = struct(
       standard=0,
@@ -64,8 +66,11 @@ class Camera(Parameters):
     return Camera.model[model] | cv2.CALIB_FIX_ASPECT_RATIO * fix_aspect
 
   @staticmethod
-  def calibrate(boards, detections, image_size, max_iter=10, eps=1e-3,
+  def calibrate(boards, intrinsic_error_limit, detections, image_size, max_iter=10, eps=1e-3,
                 model='standard', fix_aspect=False, has_skew=False, flags=0, max_images=None):
+    '''
+    iteratively selects best images to calculate intrinsic parameters
+    '''
 
     points = calibration_points(boards, detections)
     if max_images is not None:
@@ -76,11 +81,28 @@ class Camera(Parameters):
                 cv2.TERM_CRITERIA_MAX_ITER, max_iter, eps)
     flags = Camera.flags(model, fix_aspect) | flags
 
-    err, K, dist, _, _ = cv2.calibrateCamera(points.object_points,
-            points.corners, image_size, None, None, criteria=criteria, flags=flags)
+    err = intrinsic_error_limit
+    while abs(err) >= intrinsic_error_limit:
+      err, K, dist, r, t, _, _, error_perView = cv2.calibrateCameraExtended(points.object_points, points.corners,
+                                                                            image_size, None, None, criteria=criteria,
+                                                                            flags=flags)
+      if len(error_perView) >= 15:
+        err = float("{:.2f}".format(err))
+        threshold = np.quantile(error_perView, 0.95)
+        inliers = [(i) for i, err in enumerate(error_perView) if err < threshold]
+        points.object_points = np.array([points.object_points[i] for i in inliers], dtype=object)
+        points.corners = np.array([points.corners[i] for i in inliers], dtype=object)
+        points.ids = np.array([points.ids[i] for i in inliers], dtype=object)
+        points.board_offset = np.array([points.board_offset[i] for i in inliers], dtype=object)
+        points.image_ids = np.array([points.image_ids[i] for i in inliers], dtype=object)
+      else:
+        intrinsic_error_limit += 0.1
 
     return Camera(intrinsic=K, dist=dist, image_size=image_size,
-                  model=model, fix_aspect=fix_aspect, has_skew=has_skew), err
+                  model=model, fix_aspect=fix_aspect, has_skew=has_skew,
+                  error_perview=error_perView,
+                  intrinsic_dataset={'board_ids': list(points.board_offset), 'image_ids': list(points.image_ids)}
+                  ), err
 
   def scale_image(self, factor):
     intrinsic = self.intrinsic.copy()
@@ -159,17 +181,18 @@ class Camera(Parameters):
     return Camera(**d)
 
 
-def board_correspondences(board, detections):
+def board_correspondences(board_id, board, detections):
   non_empty = [d for d in detections if board.has_min_detections(d)]
+  img_ids = [id for id, d in enumerate(detections) if board.has_min_detections(d)]
   if len(non_empty) == 0:
-    return struct(corners = [], object_points=[], ids=[])
+    return struct(corners = [], object_points=[], ids=[], board_offset= [], image_ids=[])
 
   detections = transpose_structs(non_empty)
   return detections._extend(
       object_points=[board.points[ids].astype(np.float32) for ids in detections.ids],
-      corners=[corners.astype(np.float32) for corners in detections.corners]
+      corners=[corners.astype(np.float32) for corners in detections.corners],
+      board_offset=list(np.ones(len(img_ids))*board_id), image_ids=img_ids
   )
-
 
 def board_frames(board, detections):
   non_empty = [d for d in detections if board.has_min_detections(d)]
@@ -203,20 +226,18 @@ def top_detection_coverage(detections, k, image_size, approx_bins=10, jitter=0.1
   sorted = detections._map(index_list, np.argsort(sizes))
   return sorted._map(lambda xs: xs[:k])
 
-
 def calibration_points(boards, detections):
 
   board_detections = transpose_lists(detections)
-  board_points = [board_correspondences(board, detections) for board, detections
-                  in zip(boards, board_detections)]
+  board_points = [board_correspondences(board_id, board, detections) for board_id, (board, detections)
+                  in enumerate(zip(boards, board_detections))]
 
   return reduce(operator.add, board_points)
 
-
-def calibrate_cameras(boards, points, image_sizes, **kwargs):
+def calibrate_cameras(boards, points, image_sizes, intrinsic_error_limit, **kwargs):
 
   with ThreadPool() as pool:
-    f = partial(Camera.calibrate, boards, **kwargs)
+    f = partial(Camera.calibrate, boards, intrinsic_error_limit, **kwargs)
     return transpose_lists(pool.starmap(f, zip(points, image_sizes)))
 
 

--- a/multical/config/arguments.py
+++ b/multical/config/arguments.py
@@ -34,6 +34,7 @@ class CameraOpts:
   distortion_model: str = choice("standard", "rational", "thin_prism", "tilted", default="standard")
   motion_model: str = choice("rolling", "static", default="static")  # Camera motion model to use
   isFisheye: bool = False # Use fisheye camera -> changes distortion models
+  intrinsic_error_limit: float = 0.5  # for iterative intrinsic calculation
   
   calibration: Optional[str] = None # Initialise from previous (or single camera) calibration
   limit_intrinsic: Optional[int] = 50   # Limit intrinsic images to enable faster initialisation
@@ -45,6 +46,10 @@ class RuntimeOpts:
   log_level: str = choice('INFO', 'DEBUG', 'WARN', default='INFO') # Minimum log level
   no_cache: bool = False # Don't attempt to load detections from cache
   seed : int = 0 # Seed for repeatable runs
+  exclude_bad_poses : bool = True # Exclude poses which has error greater than pose_error_limit
+  pose_error_limit: float = 1.0
+  is_non_overlapping: bool = False  # for non-overlapping case consider hand-eye calibration
+
 
 @dataclass 
 class OptimizerOpts:

--- a/multical/config/workspace.py
+++ b/multical/config/workspace.py
@@ -28,7 +28,7 @@ def initialise_with_images(ws : Workspace, boards, camera_images,
     if calib is not None:
       ws.set_calibration(calib.cameras)
     else:
-      ws.calibrate_single(camera_opts.distortion_model, 
+      ws.calibrate_single(camera_opts.distortion_model, camera_opts.intrinsic_error_limit,
           fix_aspect=camera_opts.fix_aspect,
           has_skew=camera_opts.allow_skew, 
           max_images=camera_opts.limit_intrinsic,
@@ -36,7 +36,10 @@ def initialise_with_images(ws : Workspace, boards, camera_images,
 
     ws.initialise_poses(
         motion_model=get_motion_model(camera_opts.motion_model),
-        camera_poses=calib.camera_poses if calib is not None else None
+        camera_poses=calib.camera_poses if calib is not None else None,
+        exclude_bad_poses=runtime.exclude_bad_poses,
+        pose_error_limit=runtime.pose_error_limit,
+        is_non_overlapping=runtime.is_non_overlapping
       )
     return ws
 

--- a/multical/hand_eye/hand_eye.py
+++ b/multical/hand_eye/hand_eye.py
@@ -1,0 +1,124 @@
+import os.path
+
+from structs.numpy import shape_info, struct, Table, shape
+import numpy as np
+from multical.transform import matrix
+import json
+import pickle
+import gc
+from .helper import *
+from multical.io.logging import debug, info
+import cv2
+class HandEye():
+  def __init__(self, pose_table, cam_name, image_path):
+      assert isinstance(pose_table, Table)
+      self.cam_names = cam_name
+      self.pose_table = pose_table
+      self.image_path = image_path
+      self.num_cameras = self.pose_table._prefix[0]
+      self.num_images = self.pose_table._prefix[1]
+      self.num_boards = self.pose_table._prefix[2]
+      self.viewed_boards = self.check_viewed_boards()
+      self.camera_poses = {}
+      self.camera_groups = {}
+      self.reference_camera = None
+      self.cam_init = {}
+      self.handeye_df = []
+
+  def check_viewed_boards(self):
+      limit_board_image = 6
+      boards = {}
+      for idx, cam in enumerate(self.cam_names):
+          boards[cam] = [b for b in range(0, self.num_boards) if
+                           self.pose_table.valid[idx][:, b].sum() > limit_board_image]
+      return boards
+  def initialise_camera_poses(self):
+      max_density = 0
+      max_group = 0
+      for idm, master_cam in enumerate(self.cam_names):
+          temp_density = 0
+          temp_group = 0
+          self.camera_poses[master_cam] = {}
+          self.camera_groups[master_cam] = {}
+          self.camera_poses[master_cam][master_cam] = np.eye(4).tolist()
+          for ids, slave_cam in enumerate(self.cam_names):
+              if slave_cam != master_cam:
+                  cs_wrto_cm = []
+                  for boardM in self.viewed_boards[master_cam]:
+                      for boardS in self.viewed_boards[slave_cam]:
+                          slaveCam_wrt_masterCam, image_ids = self.master_slave_pair(idm, ids, boardM, boardS)
+                          if slaveCam_wrt_masterCam is not None:
+                              self.handeye_df.append({"master_cam": master_cam, "slave_cam":slave_cam, "boardM": boardM, "boardS":boardS,
+                                                      "image_ids": image_ids, "slaveCam_wrt_masterCam":slaveCam_wrt_masterCam})
+                              cs_wrto_cm.append(slaveCam_wrt_masterCam)
+                  self.camera_groups[master_cam][slave_cam] = [g.tolist() for g in cs_wrto_cm]
+                  density, self.camera_poses[master_cam][slave_cam] = probabilistic_guess(cs_wrto_cm)
+                  temp_density += density
+                  temp_group += len(cs_wrto_cm)
+          # for choosing reference camera
+          if (temp_density > max_density and temp_group > max_group):
+              max_density = temp_density
+              max_group = temp_group
+              self.reference_camera = master_cam
+
+      self.camera_poses['Reference_camera'] = self.reference_camera
+      # Export all groups and group mean
+      with open(os.path.join(self.image_path, 'camera_groups.pkl'), 'wb') as f:
+          pickle.dump(self.camera_groups, f)
+      del self.camera_groups
+      gc.collect()
+
+      with open(os.path.join(self.image_path,'initial_guess.json'), 'w') as fp:
+          json.dump(self.camera_poses, fp)
+
+      info(f"Reference camera {self.reference_camera} with density {max_density} and number of groups {max_group}")
+      init0 = relative_to_cam(self.cam_names[0], self.camera_poses[self.reference_camera])
+      # for Multical camera pose, we need masterCam_wrto_slaveCam
+      for k in self.cam_names:
+          init0[k] = np.linalg.inv(init0[k])
+      self.cam_init = init0
+
+
+  def master_slave_pair(self, master_cam, slave_cam, boardM, boardS):
+      """
+      master_cam : Reference camera
+      slave_cam : Cameras except master_cam
+      boardM : Boards that are viewed by the master_cam
+      boardS : Boards that are viewed by a slave_cam
+      """
+      table_m = self.pose_table._index_select(master_cam, axis=0)._index_select(boardM, axis=1)
+      table_s = self.pose_table._index_select(slave_cam, axis=0)._index_select(boardS, axis=1)
+
+      valid_images = table_m.valid & table_s.valid
+      image_ids = np.flatnonzero(valid_images)
+      if len(image_ids) < 3:
+          return None, None
+      master_poses = [np.linalg.inv(p) for p in table_m.poses[image_ids]]
+      slave_poses = [np.linalg.inv(p) for p in table_s.poses[image_ids]]
+      master_R = [matrix.split(p)[0] for p in master_poses]
+      master_t = [matrix.split(p)[1] for p in master_poses]
+      slave_R = [matrix.split(p)[0] for p in slave_poses]
+      slave_t = [matrix.split(p)[1] for p in slave_poses]
+
+      (slaveCam_wrt_masterCam, slaveB_wrt_masterB) = self.hand_eye_robot_world(master_R, master_t, slave_R, slave_t)
+      if slaveB_wrt_masterB is not None:
+        return slaveCam_wrt_masterCam, image_ids
+      else:
+        return None, None
+
+  @staticmethod
+  def hand_eye_robot_world(cam_world_R, cam_world_t, base_gripper_R, base_gripper_t):
+      try:
+          base_cam_r, base_cam_t, gripper_world_r, gripper_world_t = \
+            cv2.calibrateRobotWorldHandEye(cam_world_R, cam_world_t, base_gripper_R, base_gripper_t, method=cv2.CALIB_ROBOT_WORLD_HAND_EYE_SHAH)
+
+          base_wrt_cam = matrix.join(base_cam_r, base_cam_t.reshape(-1))
+          gripper_wrt_world = matrix.join(gripper_world_r, gripper_world_t.reshape(-1))
+          return base_wrt_cam, gripper_wrt_world
+      except:
+          print('normalizeRotation error')
+          ## Add Rotation Normalization check
+          return None, None
+
+
+

--- a/multical/hand_eye/helper.py
+++ b/multical/hand_eye/helper.py
@@ -1,0 +1,24 @@
+import numpy as np
+from multical.tables import *
+from multical.transform import *
+from scipy import stats
+def probabilistic_guess(transformations_list):
+    """
+    Selects the best translation vector (position of camera) from all Master-Slave groups
+    """
+    assert isinstance(transformations_list, list) and transformations_list[0].shape == (4,4)
+    x = [rtvec.as_rtvec(p)[3:][0] for p in transformations_list]
+    y = [rtvec.as_rtvec(p)[3:][1] for p in transformations_list]
+    z = [rtvec.as_rtvec(p)[3:][2] for p in transformations_list]
+
+    xyz = np.vstack([x, y, z])
+    kde = stats.gaussian_kde(xyz)
+    density = kde(xyz)
+    max_idx = np.argmax(density)
+    return density[max_idx], transformations_list[max_idx].tolist()
+
+def relative_to_cam(new_ref, camera_poses):
+    new_pose = np.linalg.inv(camera_poses[new_ref])
+    for k, v in camera_poses.items():
+        camera_poses[k] = new_pose @ camera_poses[k]
+    return camera_poses

--- a/multical/io/detections.py
+++ b/multical/io/detections.py
@@ -1,7 +1,7 @@
 
 import pickle
 from multical.io.logging import info
-
+import os
 from structs.struct import struct
 
 def try_load_detections(filename, cache_key={}):
@@ -10,13 +10,41 @@ def try_load_detections(filename, cache_key={}):
       loaded = pickle.load(file)
       
       # Check that the detections match the metadata
-      if (loaded.get('cache_key', {}) == cache_key):
+      if (loaded.get('cache_key', {}) == cache_key or check_dataset_similarity(loaded, cache_key)):
         info(f"Loaded detections from {filename}")
         return loaded.detected_points
       else:
         info(f"Config changed, not using loaded detections in {filename}")
   except (OSError, IOError, EOFError, AttributeError) as e:
     return None
+
+def check_dataset_similarity(loaded, cache_key):
+  '''
+  Checks whether the loaded datasets file format is similar to cached dataset
+  '''
+  filenames = loaded.cache_key['filenames']
+  caches = cache_key['filenames']
+
+  assert len(filenames) == len(caches)
+  for i in range(len(filenames)):
+    assert len(filenames[i]) == len(caches[i])
+    for j in range(len(filenames[i])):
+      file_dirs = find_char(filenames[i][j])
+      cache_dirs = find_char(caches[i][j])
+      if (file_dirs[-3:] == cache_dirs[-3:]):
+        continue
+      else:
+        return False
+
+  return True
+
+def find_char(str):
+  '''
+  Helper function for check_dataset_similarity function
+  '''
+  x = str.split("\\")
+  y = str.split("/")
+  return x if len(x) > len(y) else y
 
 def write_detections(filename, detected_points, cache_key={}):
   data = struct(

--- a/multical/transform/rtvec.py
+++ b/multical/transform/rtvec.py
@@ -52,4 +52,7 @@ def as_rtvec(extrinsic):
   else:
     assert False, f"expected extrinsic of shape 6 or 4x4, got: {extrinsic.shape}"
 
-
+def rtvec_to_euler(poses):
+  r = R.from_rotvec(poses[0:3].reshape(-1))
+  euler_deg = r.as_euler('xyz', degrees=True)
+  return euler_deg


### PR DESCRIPTION
This repository was incredibly helpful during my master's thesis. In our use case, we worked with 6 cameras that did not have overlapping views. To address this, I used an icosahedron as the calibration object. The dataset for this project is available [here](https://zenodo.org/records/13294455)
 
<img src="https://github.com/user-attachments/assets/2b58c4cb-cdc6-49ba-b1d0-63af123a6473" width="300" height="300">
<img src="https://github.com/user-attachments/assets/9256dff5-e3c8-463b-a43d-588e74d33182" width="300" height="300">

In this pull request, I have added the following:

1. A hand-eye calibration method to address the non-overlapping camera scenario.
2. An iterative approach for calculating intrinsic parameters, which proves more robust for large datasets and reduces the need to manually select suitable images for intrinsic calibration.
3. Functionality to reject outlier poses from further calculations.

The complete visualization for initial guess for camera extrinsic calibration and the final estimation is available [here](https://chart-studio.plotly.com/~Tabassum_Nova/7/#/plot)
![ex_viz1](https://github.com/user-attachments/assets/f9b0bba8-6e36-42f2-be33-d7ca540b2795)

