### PR TITLE
Fix the incorrect method of setting the distortion model flag

### DIFF
--- a/multical/camera.py
+++ b/multical/camera.py
@@ -43,8 +43,8 @@ class Camera(Parameters):
   model = struct(
       standard=0,
       rational=cv2.CALIB_RATIONAL_MODEL,
-      tilted=cv2.CALIB_RATIONAL_MODEL | cv2.CALIB_TILTED_MODEL,
-      thin_prism=cv2.CALIB_RATIONAL_MODEL | cv2.CALIB_TILTED_MODEL | cv2.CALIB_THIN_PRISM_MODEL,
+      thin_prism=cv2.CALIB_RATIONAL_MODEL | cv2.CALIB_THIN_PRISM_MODEL,
+      tilted=cv2.CALIB_RATIONAL_MODEL | cv2.CALIB_THIN_PRISM_MODEL | cv2.CALIB_TILTED_MODEL,
   )
 
   def __str__(self):

--- a/multical/camera.py
+++ b/multical/camera.py
@@ -42,9 +42,9 @@ class Camera(Parameters):
 
   model = struct(
       standard=0,
-      rational=cv2.CALIB_RATIONAL_MODEL,
-      tilted=cv2.CALIB_TILTED_MODEL,
-      thin_prism=cv2.CALIB_THIN_PRISM_MODEL
+      rational=cv2.CALIB_RATIONAL_MODEL | cv2.CALIB_TILTED_MODEL * False | cv2.CALIB_THIN_PRISM_MODEL * False,
+      tilted=cv2.CALIB_RATIONAL_MODEL | cv2.CALIB_TILTED_MODEL | cv2.CALIB_THIN_PRISM_MODEL * False,
+      thin_prism=cv2.CALIB_RATIONAL_MODEL | cv2.CALIB_TILTED_MODEL | cv2.CALIB_THIN_PRISM_MODEL,
   )
 
   def __str__(self):

--- a/multical/camera.py
+++ b/multical/camera.py
@@ -42,8 +42,8 @@ class Camera(Parameters):
 
   model = struct(
       standard=0,
-      rational=cv2.CALIB_RATIONAL_MODEL | cv2.CALIB_TILTED_MODEL * False | cv2.CALIB_THIN_PRISM_MODEL * False,
-      tilted=cv2.CALIB_RATIONAL_MODEL | cv2.CALIB_TILTED_MODEL | cv2.CALIB_THIN_PRISM_MODEL * False,
+      rational=cv2.CALIB_RATIONAL_MODEL,
+      tilted=cv2.CALIB_RATIONAL_MODEL | cv2.CALIB_TILTED_MODEL,
       thin_prism=cv2.CALIB_RATIONAL_MODEL | cv2.CALIB_TILTED_MODEL | cv2.CALIB_THIN_PRISM_MODEL,
   )
 


### PR DESCRIPTION
The previous way of setting distortion model is wrong.
For example, if you want to use thin-prism model, but you only set cv2.CALIB_THIN_PRISM_MODEL as True, not  cv2.CALIB_RATIONAL_MODEL and cv2.CALIB_TILTED_MODEL, the calibration result sucks. 
Thin-prism model must have other polynomial coefficients which is enabled by setting cv2.CALIB_RATIONAL_MODEL and cv2.CALIB_TILTED_MODEL as True.

I fixed above problem.